### PR TITLE
feat(workflow): refactor state handling and enhance document status indicators

### DIFF
--- a/frappe_workflow_extension/frappe_workflow_extension/doctype/nl_workflow_action/nl_workflow_action.py
+++ b/frappe_workflow_extension/frappe_workflow_extension/doctype/nl_workflow_action/nl_workflow_action.py
@@ -17,8 +17,8 @@ from frappe.utils.verified_command import get_signed_params, verify_request
 from ...workflow import (
     apply_workflow,
     get_allowed_transitions_for_user,
+    get_doc_workflow_state,
     get_workflow_name,
-    get_workflow_state_field,
     has_approval_access,
     is_transition_condition_satisfied,
     send_email_alert,
@@ -322,9 +322,7 @@ def get_allowed_roles(user, workflow, workflow_state):
 
 
 def get_next_possible_transitions(workflow_name, state, doc=None):
-    print(workflow_name, state, "workflow in get_next_possible_transitions", "\n\n\n")
     transitions = get_allowed_transitions_for_user(workflow_name, state)
-    print(transitions, "transitions in get_next_possible_transitions", "\n\n\n")
     transitions_to_return = []
 
     for transition in transitions:
@@ -484,12 +482,6 @@ def clear_workflow_actions(doctype, name):
             "reference_doctype": doctype,
         },
     )
-
-
-def get_doc_workflow_state(doc):
-    workflow_name = get_workflow_name(doc.get("doctype"), doc.get("name"))
-    workflow_state_field = get_workflow_state_field(workflow_name)
-    return doc.get(workflow_state_field)
 
 
 def get_common_email_args(doc):

--- a/frappe_workflow_extension/frappe_workflow_extension/workflow.py
+++ b/frappe_workflow_extension/frappe_workflow_extension/workflow.py
@@ -12,6 +12,12 @@ from frappe.model.document import Document
 from frappe.utils import cint
 
 
+def get_doc_workflow_state(doc):
+    workflow_name = get_workflow_name(doc.get("doctype"), doc.get("name"))
+    workflow_state_field = get_workflow_state_field(workflow_name)
+    return doc.get(workflow_state_field)
+
+
 def get_workflow_name(doctype: str, docname: str = None) -> str | None:
     company = project = user = None
 
@@ -46,6 +52,7 @@ def get_workflow_name(doctype: str, docname: str = None) -> str | None:
     return None
 
 
+@frappe.whitelist()
 def get_workflow(doctype: str, docname: str = None):
     """Return cached NL Workflow document for the given doctype."""
     workflow_name = get_workflow_name(doctype, docname)
@@ -260,9 +267,39 @@ def show_progress(docnames, message, i, description):
 
 
 @frappe.whitelist()
-def has_workflow(doctype: str, docname: str = None) -> str | None:
-    """Return active NL Workflow name if it exists for the given doctype."""
-    return get_workflow_name(doctype, docname)
+def get_workflow_info(doc: dict | str):
+    if isinstance(doc, str):
+        doc = json.loads(doc)
+
+    workflow_name = get_workflow_name(doc.get("doctype"), doc.get("name"))
+    if not workflow_name:
+        return None
+
+    workflow = frappe.get_cached_doc("NL Workflow", workflow_name)
+    allow_edit = False
+    user = frappe.session.user
+    user_roles = frappe.get_roles(user)
+
+    workflow_state = get_doc_workflow_state(doc)
+
+    state = next((s for s in workflow.states if s.state == workflow_state), None)
+
+    if state:
+        if state.edit_permission_type == "User":
+            if state.allow_edit == user:
+                allow_edit = True
+        elif state.edit_permission_type == "Role":
+            allowed_role = state.allow_edit
+            if allowed_role:
+                if isinstance(allowed_role, str):
+                    allowed_role = allowed_role.strip()
+                if allowed_role in user_roles:
+                    allow_edit = True
+
+    result = {"workflow": workflow.as_dict()}
+    if allow_edit:
+        result["allow_edit"] = allow_edit
+    return result
 
 
 @frappe.whitelist()

--- a/frappe_workflow_extension/public/js/nl_workflow.js
+++ b/frappe_workflow_extension/public/js/nl_workflow.js
@@ -4,15 +4,22 @@ $(document).on("form-refresh", function (event, frm) {
 
 	try {
 		frappe.call({
-			method: "frappe_workflow_extension.frappe_workflow_extension.workflow.has_workflow",
-			args: { doctype: frm.doctype, docname: frm.doc.name },
+			method: "frappe_workflow_extension.frappe_workflow_extension.workflow.get_workflow_info",
+			args: { doc: frm.doc },
 			callback: function (res) {
-				const workflow_name = res.message;
+				const workflow = res.message.workflow;
+				const workflow_name = res.message.workflow.name;
+				if (!workflow) return;
+
+				if (!res.message.allow_edit) {
+					frm.set_read_only(true);
+				}
 
 				const has_workflow = !!workflow_name;
 				if (has_workflow) {
 					frm.page.clear_primary_action();
-					override_document_status(frm);
+					if (!workflow.override_status)
+						override_document_status(frm, workflow.workflow_state_field);
 				}
 
 				if (workflow_name) {
@@ -31,6 +38,7 @@ function load_allowed_transitions(frm, workflow_name) {
 		args: { doc: frm.doc, workflow: workflow_name },
 		callback: function (r) {
 			const transitions = r.message || [];
+
 			frm.page.clear_actions_menu();
 
 			if (!transitions.length) return;
@@ -107,26 +115,107 @@ function add_workflow_help_action(frm, transitions) {
 	}
 }
 
-function override_document_status(frm) {
+function override_document_status(frm, workflow_state_field) {
 	try {
-		const state_field = frappe.workflow.get_state_fieldname(frm.doctype);
-		const current_state = frm.doc[state_field];
-		let status_label = "";
-		let color = "gray";
-		if (frm.doc.docstatus === 0) {
-			status_label = __("Draft");
-			color = "gray";
-		} else if (frm.doc.docstatus === 1) {
-			status_label = current_state ? __(current_state) : __("Submitted");
-			color = "blue";
-		} else if (frm.doc.docstatus === 2) {
-			status_label = __("Cancelled");
-			color = "red";
-		}
-		if (frm.page && frm.page.set_indicator) {
-			frm.page.set_indicator(status_label, color);
+		const doc = frm.doc;
+		const doctype = frm.doctype;
+		if (!doc || !doctype) return;
+
+		let label = __("Unknown");
+		let filter = null;
+
+		const meta = frappe.get_meta(doctype);
+		const is_submittable = meta?.is_submittable;
+
+		if (doc.__unsaved) {
+			label = __("Not Saved");
+			const color = "orange";
+			if (frm.page && typeof frm.page.set_indicator === "function") {
+				frm.page.set_indicator(label, color);
+			}
+		} else if (workflow_state_field && doc[workflow_state_field]) {
+			const value = doc[workflow_state_field];
+			label = __(value);
+			filter = `${workflow_state_field},=,${value}`;
+
+			frappe.call({
+				method: "frappe.client.get_value",
+				args: {
+					doctype: "Workflow State",
+					fieldname: "style",
+					filters: { name: value },
+				},
+				callback: function (r) {
+					let color = "gray";
+					if (r.message && r.message.style) {
+						const style = r.message.style;
+						color =
+							{
+								Success: "green",
+								Warning: "orange",
+								Danger: "red",
+								Primary: "blue",
+								Inverse: "black",
+								Info: "light-blue",
+							}[style] || "gray";
+					}
+					if (frm.page && typeof frm.page.set_indicator === "function") {
+						frm.page.set_indicator(label, color, filter);
+					}
+				},
+			});
+		} else if (is_submittable && doc.docstatus === 0) {
+			label = __("Draft");
+			const color = "red";
+			filter = "docstatus,=,0";
+			if (frm.page && typeof frm.page.set_indicator === "function") {
+				frm.page.set_indicator(label, color, filter);
+			}
+		} else if (is_submittable && doc.docstatus === 1) {
+			label = __("Submitted");
+			const color = "blue";
+			filter = "docstatus,=,1";
+			if (frm.page && typeof frm.page.set_indicator === "function") {
+				frm.page.set_indicator(label, color, filter);
+			}
+		} else if (is_submittable && doc.docstatus === 2) {
+			label = __("Cancelled");
+			const color = "red";
+			filter = "docstatus,=,2";
+			if (frm.page && typeof frm.page.set_indicator === "function") {
+				frm.page.set_indicator(label, color, filter);
+			}
+		} else if (doc.status && meta?.states?.find((d) => d.title === doc.status)) {
+			const state = meta.states.find((d) => d.title === doc.status);
+			label = __(doc.status);
+			const color = frappe.scrub(state.color, "-");
+			filter = `status,=,${doc.status}`;
+			if (frm.page && typeof frm.page.set_indicator === "function") {
+				frm.page.set_indicator(label, color, filter);
+			}
+		} else if (doc.status) {
+			label = __(doc.status);
+			const color = frappe.utils.guess_colour(doc.status);
+			filter = `status,=,${doc.status}`;
+			if (frm.page && typeof frm.page.set_indicator === "function") {
+				frm.page.set_indicator(label, color, filter);
+			}
+		} else if (frappe.meta.has_field(doctype, "enabled")) {
+			label = doc.enabled ? __("Enabled") : __("Disabled");
+			const color = doc.enabled ? "blue" : "gray";
+			filter = `enabled,=,${doc.enabled ? 1 : 0}`;
+			if (frm.page && typeof frm.page.set_indicator === "function") {
+				frm.page.set_indicator(label, color, filter);
+			}
+		} else if (frappe.meta.has_field(doctype, "disabled")) {
+			label = doc.disabled ? __("Disabled") : __("Enabled");
+			const color = doc.disabled ? "gray" : "blue";
+			filter = `disabled,=,${doc.disabled ? 1 : 0}`;
+			if (frm.page && typeof frm.page.set_indicator === "function") {
+				frm.page.set_indicator(label, color, filter);
+			}
 		}
 	} catch (error) {
-		console.warn(" Failed to override document status:", error);
+		console.warn("Failed to override document status:", error);
 	}
 }


### PR DESCRIPTION
Enhances workflow management and UI indicators:

- Moved `get_doc_workflow_state` to `workflow.py` for better organization.
- Added `get_workflow_info` endpoint to handle workflow state and edit permissions.
- Improved document status indicators with granular state handling and color coding.
- Removed debug print statements and improved error handling.
- Added proper state validation for different document types.

These changes improve permission control through workflow states and provide clearer visual feedback on document status throughout the application.