### PR TITLE
fix: correct NL Workflow query dimension handling

### DIFF
--- a/frappe_workflow_extension/frappe_workflow_extension/doctype/nl_workflow/nl_workflow.py
+++ b/frappe_workflow_extension/frappe_workflow_extension/doctype/nl_workflow/nl_workflow.py
@@ -172,16 +172,18 @@ class NLWorkflow(Document):
             "cost_center": self.cost_center or ["in", [None, ""]],
         }
 
+        new_accounting_dimensions = []
         for dimension in accounting_dimensions:
-            if hasattr(self, dimension) and getattr(self, dimension):
-                filters[dimension] = getattr(self, dimension)
-            else:
-                filters[dimension] = ["in", [None, ""]]
+            if hasattr(self, dimension):
+                new_accounting_dimensions.append(dimension)
+
+                if getattr(self, dimension):
+                    filters[dimension] = getattr(self, dimension)
 
         existing_workflows = frappe.get_all(
             "NL Workflow",
             filters=filters,
-            fields=["name", "document_type"] + accounting_dimensions,
+            fields=["name", "document_type", *new_accounting_dimensions],
         )
 
         if existing_workflows:


### PR DESCRIPTION
- Only include accounting dimensions that exist on the document when building NL Workflow lookup fields, and only apply dimension filters when a value is set. This avoids querying/returning invalid dimensions and reduces unintended filtering.